### PR TITLE
feat: Support Mongo SRV url type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,139 @@
-build
-dist
-wait_for_dep.egg-info
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+.venv

--- a/README.md
+++ b/README.md
@@ -118,14 +118,17 @@ MongoDB has to accept connection.
 ### Installation
 ```
 pip install wait-for-dep[mongodb]
+pip install wait-for-dep[mongodb_srv]
 ```
 
 ### Accepted URL schemas
 * mongodb://
+* mongodb+srv:// #Requires mongodb_srv bundle
 
 ### Example
 ```
 wait-for-dep mongodb://admin:password@db-host/db_name
+wait-for-dep mongodb+srv://admin:password@db-host/db_name
 ```
 
 

--- a/requirements/extras/mongodb_srv.txt
+++ b/requirements/extras/mongodb_srv.txt
@@ -1,0 +1,1 @@
+pymongo[srv]

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
             "wait-for-dep = wait_for_dep.wait_for_dep:main",
         ],
     },
-    version="0.3.2",
+    version="0.3.2.1",
     description="Waits for dependencies before running the app",
     url="http://github.com/wlatanowicz/wait-for-dep",
     author="Wiktor Latanowicz",

--- a/wait_for_dep/checks/mongodb.py
+++ b/wait_for_dep/checks/mongodb.py
@@ -3,7 +3,7 @@ import pymongo
 
 def check(url):
     try:
-        pymongo.MongoClient(url)
+        pymongo.MongoClient(url,connect=True)
         return True
     except:
         return False

--- a/wait_for_dep/wait_for_dep.py
+++ b/wait_for_dep/wait_for_dep.py
@@ -3,6 +3,7 @@ import sys
 import time
 import re
 from urllib.parse import urlparse
+import argparse
 
 scheme_type = r"[a-z0-9]+"
 
@@ -62,11 +63,18 @@ class WaitForDep:
 
 def main():
     w = WaitForDep()
-    args = sys.argv
-    args.pop(0)
-
-    for url in args:
-        w.wait(url)
+    
+    
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('urls', metavar='N', type=str, nargs='+',
+                        help='space seperated list of urls to check')
+    
+    args = parser.parse_args()
+    urls = args.urls
+    
+    for url in urls:
+        if not url == "":
+            w.wait(url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* update .gitignore for standard python exclusions
* If falling back to TCP checks and there is no port report and error
* Accept mongodb srv urls i.e "mongodb+srv://something"